### PR TITLE
doc: replace npm run with yarn

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -23,12 +23,12 @@ trade-off, mainly completeness vs. speed.
 ### React API level
 
 #### Run the core mocha unit/integration test suite.
-To run all of the unit tests just run  `npm run test:unit`
+To run all of the unit tests just run  `yarn test:unit`
 
 If you want to `grep` for certain tests just add `-- -g STRING_TO_GREP` and change STRING_TO_GREP.
 
 #### Watch the core mocha unit/integration test suite.
-`npm run test:watch`
+`yarn test:watch`
 
 First, we have the **unit test** suite.
 It uses [mocha](https://mochajs.org) and the *shallow* API of [enzyme](https://github.com/airbnb/enzyme) to allow testing the components in isolation.
@@ -43,14 +43,14 @@ It's here to make sure components work together.
 Here is an [example](https://github.com/material-next/material-next/blob/a3719a203515b1ad683e62085cb5065318c0c87f/test/integration/Menu.spec.js#L29) with the `Menu` component.
 
 #### Create HTML coverage reports
-`npm run test:coverage:html`
+`yarn test:coverage:html`
 
 When running this command you should get under `coverage/index.html` a full coverage report in HTML format. This is created using [Istanbul](http://istanbul-js.org)'s HTML reporter and gives good data such as line, branch and function coverage.
 
 ### DOM API level
 
 #### Run the mocha test suite using the karma runner.
-`npm run test:karma`
+`yarn test:karma`
 
 Testing the components at the React level isn't enough;
 we need to make sure they will behave as expected with a **real DOM**.
@@ -67,7 +67,7 @@ The DOM is just one dimension of that environment,
 so we also need to take into account the rendering engine.
 
 #### Run the visual regression tests
-`npm run test:regressions`
+`yarn test:regressions`
 
 Next, we are using [docker](https://github.com/docker/docker) to take screenshots and comparing them with the baseline. It allows catching regressions like this one:
 


### PR DESCRIPTION
`s/npm run/yarn/g`

As you're mentioning yarn instead of npm everywhere else.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
